### PR TITLE
Updates RubyConf PT dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ NOTE: Follow [@rubycalendar](https://twitter.com/rubycalendar) on Twitter for ne
 #### Portugal (pt)
 
 - **RubyConf Portugal** (web: [rubyconf.pt](http://rubyconf.pt), t: [rubyconfpt](https://twitter.com/rubyconfpt))
-  - 2016 @ Braga; Oct/28+29  (€200)
+  - 2016 @ Braga; Oct/27+28  (€200)
   - 2015 @ Braga; Sept/14+15  (€250/200/150, Student €80)
   - 2014 @ Braga; Oct/13+14
 


### PR DESCRIPTION
For logistical reasons, we had to move the conference to one day earlier.
