### PR TITLE
Rails Camp 2020 added

### DIFF
--- a/_data/conferences2020.yml
+++ b/_data/conferences2020.yml
@@ -170,6 +170,17 @@
   twitter:   euruko
 
 
+- name:     Rails Camp West
+  location: Diablo Lake, Washington, United States
+  start:    2020-09-01
+  end:      2020-09-04
+  days:     4
+  month:    9
+  url:      http://west.railscamp.us/2020
+  twitter:  railscamp_usa
+  updated:  2020-01-16
+
+
 - name:      RubyC
   location:  Kyiv, Ukraine
   start:     2020-09-12


### PR DESCRIPTION
Unconference camp series for the software community to meet & learn from each other while getting out of the city to unplug around a campfire. Sept. 1-4, 2020

Question, I'd like to add it to one of these sections, because the event occurs annual every summer however the location always moves around the west coast in the USA, so I wasn't sure where to put it...for example...

```#### United States (us)

[New England](#new-england) •
[Mid Atlantic](#mid-atlantic) •
[Capital Region](#capital-region) •
[Southeast](#southeast) •
[Great Lakes](#great-lakes) •
[Great Plains](#great-plains) •
[Rocky Mountains](#rocky-mountains) •
[Southwest](#southwest) •
[Texas](#texas) •
[Pacific Northwest](#pacific-northwest) •
[California](#california)```